### PR TITLE
fix(camera-plus): retake/save buttons outside safe area

### DIFF
--- a/packages/nativescript-camera-plus/index.ios.ts
+++ b/packages/nativescript-camera-plus/index.ios.ts
@@ -523,9 +523,13 @@ class MySwifty extends SwiftyCamViewController {
 
 		if (this._snapPicOptions && this._snapPicOptions.confirm) {
 			// show the confirmation
-			const width = this.view.bounds.size.width;
-			const height = this.view.bounds.size.height;
-			this._imageConfirmBg = UIView.alloc().initWithFrame(CGRectMake(0, 0, width, height));
+			const safeAreaWidthOffset = this.view.safeAreaInsets ? this.view.safeAreaInsets.left + this.view.safeAreaInsets.right : 0;
+			const safeAreaHeightOffset = this.view.safeAreaInsets ? this.view.safeAreaInsets.bottom + this.view.safeAreaInsets.top : 0;
+			const safeAreaLeft = this.view.safeAreaInsets ? this.view.safeAreaInsets.left : 0;
+			const safeAreaTop = this.view.safeAreaInsets ? this.view.safeAreaInsets.top : 0;
+			const width = this.view.bounds.size.width - safeAreaWidthOffset;
+			const height = this.view.bounds.size.height - safeAreaHeightOffset;
+			this._imageConfirmBg = UIView.alloc().initWithFrame(CGRectMake(safeAreaLeft, safeAreaTop, width, height));
 			this._imageConfirmBg.backgroundColor = UIColor.blackColor;
 
 			// confirm user wants to keep photo


### PR DESCRIPTION
For iOS devices that have safe areas the current Retake/Save buttons are outside of it. Below is a screenshot of the issue.  This pull request detects if a safeAreaInsets are available and if so uses them.

<img width="434" alt="Screen Shot 2021-04-07 at 6 05 07 PM" src="https://user-images.githubusercontent.com/2379994/113940841-1f594a00-97cc-11eb-8f3d-05ba42eb3d76.png">
