### PR TITLE
iOS crash fix: Add error check on Exit

### DIFF
--- a/packages/nativescript-plaid/index.ios.ts
+++ b/packages/nativescript-plaid/index.ios.ts
@@ -126,21 +126,25 @@ export class PlaidLink extends PlaidLinkBase {
 			});
 		});
 		config.onExit = (result) => {
-			this.onExit({
-				error: {
-					displayMessage: result.error.localizedFailureReason,
-					code: result.error ? result.error.code.toString() : null,
-				},
-				metadata: {
-					institution: {
-						id: result.metadata.institution.ID,
-						name: result.metadata.institution.name,
-					},
-					linkSessionId: result.metadata.linkSessionID,
-					status: result.metadata.status ? result.metadata.status.value.toString() : null,
-					requestId: result.metadata.requestID,
-				},
-			});
+      if(result.error){
+        this.onExit({
+          error: {
+            displayMessage: result.error.localizedFailureReason,
+            code: result.error ? result.error.code.toString() : null,
+          },
+          metadata: {
+            institution: {
+              id: result.metadata.institution.ID,
+              name: result.metadata.institution.name,
+            },
+            linkSessionId: result.metadata.linkSessionID,
+            status: result.metadata.status ? result.metadata.status.value.toString() : null,
+            requestId: result.metadata.requestID,
+          },
+        });
+      } else {
+        this.onExit({}); 
+      }
 		};
 		config.onEvent = (result) => {
 			const plaidLink = new PlaidLink();


### PR DESCRIPTION
causes unhandled exception crash do to null result object return.  Can be reproduced by opening modal, and simply "X" closing out.