### PR TITLE
Camera Plus Ns fixes

### DIFF
--- a/packages/nativescript-camera-plus/index.android.ts
+++ b/packages/nativescript-camera-plus/index.android.ts
@@ -13,7 +13,7 @@ import { SelectedAsset } from './selected-asset';
 export * from './common';
 export { CameraVideoQuality, WhiteBalance } from './common';
 
-import fancycamera = com.github.triniwiz.fancycamera;
+import fancycamera = io.github.triniwiz.fancycamera;
 
 const REQUEST_VIDEO_CAPTURE = 999;
 const WRAP_CONTENT = -2;
@@ -203,8 +203,8 @@ export class CameraPlus extends CameraPlusBase {
 		if (this._camera && typeof ratio === 'string') {
 			const nativeSizes: any = this._camera.getAvailablePictureSizes(ratio);
 			for (const size of nativeSizes) {
-                sizes.push(`${size.getWidth()}x${size.getHeight()}`);
-            }
+				sizes.push(`${size.getWidth()}x${size.getHeight()}`);
+			}
 		}
 		return sizes;
 	}
@@ -668,7 +668,7 @@ export class CameraPlus extends CameraPlusBase {
 	public toggleFlash() {
 		if (this._camera) {
 			// @ts-ignore
-            this._camera.toggleFlash();
+			this._camera.toggleFlash();
 		}
 	}
 

--- a/packages/nativescript-camera-plus/package.json
+++ b/packages/nativescript-camera-plus/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nstudio/nativescript-camera-plus",
-	"version": "4.0.3",
+	"version": "4.0.4",
 	"description": "An advanced, embeddable camera for NativeScript.",
 	"main": "index",
 	"typings": "index.d.ts",

--- a/packages/nativescript-camera-plus/platforms/android/include.gradle
+++ b/packages/nativescript-camera-plus/platforms/android/include.gradle
@@ -1,14 +1,13 @@
 allprojects {
     repositories {
-        maven { url "https://jitpack.io" }
         google()
-        maven { url "https://dl.bintray.com/triniwiz/maven" }
+        maven { url "https://repo1.maven.org/maven2/" }
     }
 }
 
 dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation('com.github.triniwiz:fancycamera:3.0.0-alpha19'){
+    implementation('io.github.triniwiz:fancycamera:3.0.0-alpha22'){
         transitive = true
     }
 }

--- a/packages/nativescript-camera-plus/typings/android.d.ts
+++ b/packages/nativescript-camera-plus/typings/android.d.ts
@@ -1,6 +1,6 @@
 /// <reference path="android-declarations.d.ts"/>
 
-declare module com {
+declare module io {
 	export module github {
 		export module triniwiz {
 			export module fancycamera {
@@ -16,7 +16,7 @@ declare module com {
 	}
 }
 
-declare module com {
+declare module io {
 	export module github {
 		export module triniwiz {
 			export module fancycamera {
@@ -96,7 +96,7 @@ declare module com {
 	}
 }
 
-declare module com {
+declare module io {
 	export module github {
 		export module triniwiz {
 			export module fancycamera {
@@ -170,7 +170,7 @@ declare module com {
 	}
 }
 
-declare module com {
+declare module io {
 	export module github {
 		export module triniwiz {
 			export module fancycamera {
@@ -331,7 +331,7 @@ declare module com {
 	}
 }
 
-declare module com {
+declare module io {
 	export module github {
 		export module triniwiz {
 			export module fancycamera {
@@ -356,7 +356,7 @@ declare module com {
 	}
 }
 
-declare module com {
+declare module io {
 	export module github {
 		export module triniwiz {
 			export module fancycamera {
@@ -391,7 +391,7 @@ declare module com {
 	}
 }
 
-declare module com {
+declare module io {
 	export module github {
 		export module triniwiz {
 			export module fancycamera {
@@ -418,7 +418,7 @@ declare module com {
 	}
 }
 
-declare module com {
+declare module io {
 	export module github {
 		export module triniwiz {
 			export module fancycamera {
@@ -445,7 +445,7 @@ declare module com {
 	}
 }
 
-declare module com {
+declare module io {
 	export module github {
 		export module triniwiz {
 			export module fancycamera {
@@ -469,7 +469,7 @@ declare module com {
 	}
 }
 
-declare module com {
+declare module io {
 	export module github {
 		export module triniwiz {
 			export module fancycamera {
@@ -493,7 +493,7 @@ declare module com {
 	}
 }
 
-declare module com {
+declare module io {
 	export module github {
 		export module triniwiz {
 			export module fancycamera {
@@ -509,7 +509,7 @@ declare module com {
 	}
 }
 
-declare module com {
+declare module io {
 	export module github {
 		export module triniwiz {
 			export module fancycamera {
@@ -525,7 +525,7 @@ declare module com {
 	}
 }
 
-declare module com {
+declare module io {
 	export module github {
 		export module triniwiz {
 			export module fancycamera {
@@ -615,7 +615,7 @@ declare module com {
 	}
 }
 
-declare module com {
+declare module io {
 	export module github {
 		export module triniwiz {
 			export module fancycamera {
@@ -628,7 +628,7 @@ declare module com {
 	}
 }
 
-declare module com {
+declare module io {
 	export module github {
 		export module triniwiz {
 			export module fancycamera {
@@ -647,7 +647,7 @@ declare module com {
 	}
 }
 
-declare module com {
+declare module io {
 	export module github {
 		export module triniwiz {
 			export module fancycamera {
@@ -676,7 +676,7 @@ declare module com {
 	}
 }
 
-declare module com {
+declare module io {
 	export module github {
 		export module triniwiz {
 			export module fancycamera {
@@ -692,7 +692,7 @@ declare module com {
 	}
 }
 
-declare module com {
+declare module io {
 	export module github {
 		export module triniwiz {
 			export module fancycamera {
@@ -710,7 +710,7 @@ declare module com {
 	}
 }
 
-declare module com {
+declare module io {
 	export module github {
 		export module triniwiz {
 			export module fancycamera {


### PR DESCRIPTION
This fixes the issue with the current 4.x plugins no longer working because the outside maven repo was discontinued and replaced with a new repo.