### PR TITLE
Detect useAndroidX from androidx.appcompat && core

### DIFF
--- a/packages/nativescript-checkbox/index.android.ts
+++ b/packages/nativescript-checkbox/index.android.ts
@@ -8,7 +8,7 @@ const AppCompatCheckBox_Namespace = useAndroidX() ? androidx.appcompat.widget : 
 const CompoundButtonCompat_Namespace = useAndroidX() ? androidx.core.widget : (android.support.v4 as any).widget;
 
 function useAndroidX() {
-	return global.androidx && com.google && com.google.android && com.google.android.material;
+	return androidx.appcompat && androidx.core;
 }
 
 export const checkedProperty = new Property<CheckBox, boolean>({


### PR DESCRIPTION
For the NativeScript 8.2.1 app, this statement below return null in Android device. 

**global.androidx && com.google && com.google.android && com.google.android.material**

Possibly the global variables are not set properly.

I purpose another option to check whether Androidx is in used by checking the androidx.appcompat and androidx.core whether they are existing. The code change is verified and works as expected with the nativeScript 8.2.1 app in my environment.