### PR TITLE
BUG: iOS playback from ear speaker

### DIFF
--- a/packages/nativescript-exoplayer/index.ios.ts
+++ b/packages/nativescript-exoplayer/index.ios.ts
@@ -368,7 +368,7 @@ export class Video extends VideoBase {
 			if (this.backgroundAudio) {
 				audioSession.setCategoryError(AVAudioSessionCategoryAmbient);
 			} else {
-				audioSession.setCategoryError(AVAudioSessionCategoryPlayAndRecord);
+				audioSession.setCategoryError(AVAudioSessionCategoryPlayback);
 			}
 			audioSession.setActiveError(true);
 		} catch (err) {


### PR DESCRIPTION
There is an issue where the sound is outputted from the ear speaker instead of the loud speaker on iOS devices. Changing the value passed on line 371 to "AVAudioSessionCategoryPlayback" fixes the issue and now the audio outputs via loud speaker.