### PR TITLE
[EXOPLAYER] Backwards compatibility for API level less than 26

### DIFF
--- a/packages/nativescript-exoplayer/index.android.ts
+++ b/packages/nativescript-exoplayer/index.android.ts
@@ -293,8 +293,12 @@ export class Video extends VideoBase {
 
 		if (!this.backgroundAudio) {
 			const am: android.media.AudioManager = this._context.getSystemService(android.content.Context.AUDIO_SERVICE);
-			const afr = new android.media.AudioFocusRequest.Builder(android.media.AudioManager.AUDIOFOCUS_GAIN).build();
-			am.requestAudioFocus(afr);
+			if (com.google.android.exoplayer2.util.Util.SDK_INT >= 26) {
+				const afr = new android.media.AudioFocusRequest.Builder(android.media.AudioManager.AUDIOFOCUS_GAIN).build();
+				am.requestAudioFocus(afr);
+			} else {
+				am.requestAudioFocus(null, android.media.AudioManager.STREAM_MUSIC, android.media.AudioManager.AUDIOFOCUS_GAIN);
+			}
 		}
 		try {
 			const bm = new com.google.android.exoplayer2.upstream.DefaultBandwidthMeter.Builder(this._context).build();
@@ -507,8 +511,12 @@ export class Video extends VideoBase {
 			this.player.release();
 			this.player = null;
 			const am: android.media.AudioManager = this._context.getSystemService(android.content.Context.AUDIO_SERVICE);
-			const afr = new android.media.AudioFocusRequest.Builder(android.media.AudioManager.AUDIOFOCUS_GAIN).build();
-			am.abandonAudioFocusRequest(afr);
+			if (com.google.android.exoplayer2.util.Util.SDK_INT >= 26) {
+				const afr = new android.media.AudioFocusRequest.Builder(android.media.AudioManager.AUDIOFOCUS_GAIN).build();
+				am.abandonAudioFocusRequest(afr);
+			} else {
+				am.abandonAudioFocus(null);
+			}
 		}
 	}
 


### PR DESCRIPTION
* the methods requestAudioFocus and abandonAudioFocusRequest are introduced in API level 26
* use the old implementation for API Level less than 26