### PR TITLE
Force title to be a string

### DIFF
--- a/packages/nativescript-filterable-listpicker/common.ts
+++ b/packages/nativescript-filterable-listpicker/common.ts
@@ -299,7 +299,7 @@ export class FilterableListpickerCommon extends GridLayout {
     this.source = unfilteredSource.filter(item => {
       if (item.title) {
         return (
-          item.title.toLowerCase().indexOf(data.value.toLowerCase()) !== -1
+          item.title.toString().toLowerCase().indexOf(data.value.toLowerCase()) !== -1
         );
       } else {
         return item.toLowerCase().indexOf(data.value.toLowerCase()) !== -1;


### PR DESCRIPTION
Hi @davecoffin,

setting number for title such as date [2020, 2021] causing app crash `item.title.toLowerCase() is not a function` to avoid this I forced to string on it.