### PR TITLE
Update to aptabase 0.0.6

### DIFF
--- a/packages/nativescript-aptabase/README.md
+++ b/packages/nativescript-aptabase/README.md
@@ -25,7 +25,7 @@ ios: {
             name: 'Aptabase',
             libs: ['Aptabase'],
             repositoryURL: 'https://github.com/aptabase/aptabase-swift.git',
-            version: '0.0.5'
+            version: '0.0.6'
         }
     ]
 }

--- a/packages/nativescript-aptabase/platforms/android/include.gradle
+++ b/packages/nativescript-aptabase/platforms/android/include.gradle
@@ -1,3 +1,3 @@
 dependencies {
-  implementation 'com.aptabase:aptabase:0.0.5'
+  implementation 'com.aptabase:aptabase:0.0.6'
 }


### PR DESCRIPTION
0.0.6 adds support for automatic segregation of release/debug events

@NathanWalker @herefishyfish it seems like with iOS the user has to define the swift pkg on their config, while android this is built into the package.

Is it an option to have the SPM package+version built-in like Android?