### PR TITLE
Feature/getVideoSize function

### DIFF
--- a/packages/nativescript-exoplayer/index.android.ts
+++ b/packages/nativescript-exoplayer/index.android.ts
@@ -236,7 +236,10 @@ export class Video extends VideoBase {
 			},
 			onVideoSizeChanged: function (_videoSize: com.google.android.exoplayer2.video.VideoSize): void {
 				/* required in listener implementation */
-
+				const owner = that.get();
+				if (!owner) {
+					return;
+				}
 				this.videoWidth = _videoSize.width;
 				this.videoHeight = _videoSize.height;
 

--- a/packages/nativescript-exoplayer/index.android.ts
+++ b/packages/nativescript-exoplayer/index.android.ts
@@ -236,6 +236,10 @@ export class Video extends VideoBase {
 			},
 			onVideoSizeChanged: function (_videoSize: com.google.android.exoplayer2.video.VideoSize): void {
 				/* required in listener implementation */
+
+				this.videoWidth = _videoSize.width;
+				this.videoHeight = _videoSize.height;
+
 			},
 			onSurfaceSizeChanged: function (_width: number, _height: number): void {
 				/* required in listener implementation */
@@ -418,6 +422,13 @@ export class Video extends VideoBase {
 			this.startCurrentTimer();
 		}
 	}
+
+	getVideoSize() {
+        return {
+            width: this.videoWidth,
+            height: this.videoHeight
+        };
+    }
 
 	pause() {
 		if (this.player) {

--- a/packages/nativescript-exoplayer/index.android.ts
+++ b/packages/nativescript-exoplayer/index.android.ts
@@ -547,8 +547,10 @@ export class Video extends VideoBase {
 			this.nativeView.onPause();
 		}
 		// this.release();
-		this._resumeOnFocusGain = this.player.isPlaying();
-		this.player.setPlayWhenReady(false);
+		if (this.player) {
+            this._resumeOnFocusGain = this.player.isPlaying();
+            this.player.setPlayWhenReady(false);
+        }
 	}
 
 	resumeEvent() {

--- a/packages/nativescript-exoplayer/index.android.ts
+++ b/packages/nativescript-exoplayer/index.android.ts
@@ -426,6 +426,10 @@ export class Video extends VideoBase {
 		}
 	}
 
+	getPlayer() {
+		return this.player;
+	}
+
 	getVideoSize() {
         return {
             width: this.videoWidth,

--- a/packages/nativescript-exoplayer/index.android.ts
+++ b/packages/nativescript-exoplayer/index.android.ts
@@ -240,8 +240,8 @@ export class Video extends VideoBase {
 				if (!owner) {
 					return;
 				}
-				this.videoWidth = _videoSize.width;
-				this.videoHeight = _videoSize.height;
+				owner.videoWidth = _videoSize.width;
+				owner.videoHeight = _videoSize.height;
 
 			},
 			onSurfaceSizeChanged: function (_width: number, _height: number): void {

--- a/packages/nativescript-exoplayer/index.d.ts
+++ b/packages/nativescript-exoplayer/index.d.ts
@@ -152,6 +152,11 @@ export declare class Video extends View {
 	getVideoSize(): { width: number; height: number };
 
 	/**
+	 * Get the native player instance.
+	 */
+	getPlayer();
+
+	/**
 	 * *** IOS ONLY ***
 	 * Update the video player with an AVAsset file.
 	 */

--- a/packages/nativescript-exoplayer/index.d.ts
+++ b/packages/nativescript-exoplayer/index.d.ts
@@ -154,7 +154,7 @@ export declare class Video extends View {
 	/**
 	 * Get the native player instance.
 	 */
-	getPlayer();
+	getPlayer(): AVPlayer|com.google.android.exoplayer2.ExoPlayer;
 
 	/**
 	 * *** IOS ONLY ***

--- a/packages/nativescript-exoplayer/index.d.ts
+++ b/packages/nativescript-exoplayer/index.d.ts
@@ -146,6 +146,12 @@ export declare class Video extends View {
 	stop(): void;
 
 	/**
+	 * Get the video size
+	 * @returns {object<width: number, height: number>}
+	 */
+	getVideoSize(): { width: number; height: number };
+
+	/**
 	 * *** IOS ONLY ***
 	 * Update the video player with an AVAsset file.
 	 */

--- a/packages/nativescript-exoplayer/index.ios.ts
+++ b/packages/nativescript-exoplayer/index.ios.ts
@@ -275,12 +275,13 @@ export class Video extends VideoBase {
 		this._player.play();
 	}
 
+	public getPlayer() {
+		return this._player;
+	}
+
 	public getVideoSize() {
-        const r = this._playerController.videoBounds;
-        return {
-            width: r.size.width,
-            height: r.size.height
-        };
+        const size = this._player.currentItem.presentationSize;
+        return size;
     }
 
 	public pause() {

--- a/packages/nativescript-exoplayer/index.ios.ts
+++ b/packages/nativescript-exoplayer/index.ios.ts
@@ -280,8 +280,11 @@ export class Video extends VideoBase {
 	}
 
 	public getVideoSize() {
-        const size = this._player.currentItem.presentationSize;
-        return size;
+
+		if (this._player) {
+			const size = this._player.currentItem.presentationSize;
+			return size;
+		}
     }
 
 	public pause() {
@@ -462,7 +465,7 @@ export class Video extends VideoBase {
 class PlayerObserverClass extends NSObject {
 	observeValueForKeyPathOfObjectChangeContext(path: string, obj: Object, change: NSDictionary<any, any>, context: any) {
 		if (path === 'status') {
-			if (this['_owner']._player.currentItem.status === AVPlayerItemStatus.ReadyToPlay && !this['_owner']._videoLoaded) {
+			if (this['_owner']._player && this['_owner']._player.currentItem.status === AVPlayerItemStatus.ReadyToPlay && !this['_owner']._videoLoaded) {
 				this['_owner'].playbackReady();
 			}
 		}

--- a/packages/nativescript-exoplayer/index.ios.ts
+++ b/packages/nativescript-exoplayer/index.ios.ts
@@ -275,6 +275,14 @@ export class Video extends VideoBase {
 		this._player.play();
 	}
 
+	public getVideoSize() {
+        const r = this._playerController.videoBounds;
+        return {
+            width: r.size.width,
+            height: r.size.height
+        };
+    }
+
 	public pause() {
 		if (this._player) {
 			this._player.pause();


### PR DESCRIPTION
It fixes Android suspend mode crashing.
It implements a `getVideoSize()` method. For iOS it is the size of the presentation layer, and for Android, it is the size of the player view.
It implements a `getPlayer()` method to return the native Player instance.