### PR TITLE
fix(loading-indicator): android setClippingEnabled false to look edge-to-edge on Android 15+

### DIFF
--- a/packages/nativescript-loading-indicator/index.android.ts
+++ b/packages/nativescript-loading-indicator/index.android.ts
@@ -149,6 +149,10 @@ export class LoadingIndicator {
 		// handle dimming background option
 		contentView.setBackgroundColor(options.dimBackground ? new Color(255 * 0.6, 0, 0, 0).android : android.graphics.Color.TRANSPARENT);
 
+    if(options.dimBackground) {
+      this._popOver.setClippingEnabled(false);
+    }
+
 		contentView.setGravity(android.view.Gravity.CENTER);
 		contentView.setLayoutParams(new android.view.ViewGroup.LayoutParams(android.view.ViewGroup.LayoutParams.FILL_PARENT, android.view.ViewGroup.LayoutParams.FILL_PARENT));
 		const parentView = new android.widget.LinearLayout(context);


### PR DESCRIPTION
If dimBackground is true, clipping needs to be disabled on Android, so the popup is getting drawn over statusbar and navigationbar to look edge-to-edge on Android 15+